### PR TITLE
Bug correcting thedate

### DIFF
--- a/backend/database_functions/deadline_functions.py
+++ b/backend/database_functions/deadline_functions.py
@@ -49,7 +49,6 @@ def set_deadline_function(user_id, date, course_id):
     deadline_as_date = datetime.date(
         int(deadline_as_list[2]), int(deadline_as_list[1]), int(deadline_as_list[0])
     )
-    print(deadline_as_date)
     if id == None:
         target = deadlines(
             user_id=user_id, course_id=course_id, date=deadline_as_date, created_at=date_now

--- a/backend/database_functions/deadline_functions.py
+++ b/backend/database_functions/deadline_functions.py
@@ -49,9 +49,10 @@ def set_deadline_function(user_id, date, course_id):
     deadline_as_date = datetime.date(
         int(deadline_as_list[2]), int(deadline_as_list[1]), int(deadline_as_list[0])
     )
+    print(deadline_as_date)
     if id == None:
         target = deadlines(
-            user_id=user_id, course_id=course_id, date=date, created_at=date_now
+            user_id=user_id, course_id=course_id, date=deadline_as_date, created_at=date_now
         )
         db.session.add(target)
         set_checkpoints_function(
@@ -61,7 +62,7 @@ def set_deadline_function(user_id, date, course_id):
         return "Deadline added succesfully!"
     elif isinstance(id, int):
         target_dl = db.session.get(deadlines, id)
-        target_dl.date = date
+        target_dl.date = deadline_as_date
         target_dl.created_at = date_now
         deleting_existing_checkpoints_for_course(user_id, course_id)
         set_checkpoints_function(

--- a/frontend/cypress/e2e/set_deadline.cy.js
+++ b/frontend/cypress/e2e/set_deadline.cy.js
@@ -57,7 +57,7 @@ describe('TMC-Coach set deadline', { defaultCommandTimeout: 8000 }, () => {
     })
     it('deadline wont be deleted if cancel-button is clicked in confirmation window', () => {
       cy.setdeadlinepage()
-      cy.get('button.react-datepicker__navigation.react-datepicker__navigation--next').click()
+      cy.get('button.react-datepicker__navigation.react-datepicker__navigation--next').click().click()
       cy.get('div.react-datepicker__month-container').contains('27').click()
       cy.get('button[value=set_deadline]').click()
       cy.setdeadlinepage()

--- a/frontend/src/components/Deadlines.js
+++ b/frontend/src/components/Deadlines.js
@@ -48,10 +48,11 @@ const Deadlines = ({ course_id }) => {
     try {
       deadlineService.set_deadline({ course_id, date })
       setNewDeadline(true)
-      setMessage('Deadline was set successfully')
-      setTimeout(() => {
-        setMessage(null)
-      }, 10000)
+      window.location.reload()
+      //setMessage('Deadline was set successfully!')
+      //setTimeout(() => {
+      //setMessage(null)
+      //}, 10000)
     } catch (exception) {
       setMessage('Deadline could not be set')
       setTimeout(() => {
@@ -66,11 +67,12 @@ const Deadlines = ({ course_id }) => {
     if (window.confirm('Are you sure you want to delete the deadline you have set for this course?') === true) {
       try {
         await deadlineService.delete_deadline(course_id)
-        setMessage('Deleting deadline was successful!')
-        setTimeout(() => {
-          setMessage(null)
-        }, 10000)
+        //setMessage('Deleting deadline was successful!')
+        //setTimeout(() => {
+        //setMessage(null)
+        //}, 10000)
         setNewDeadline(true)
+        window.location.reload()
       } catch (exception) {
         setMessage('Deleting deadline was unsuccessful. Please try again.')
         setTimeout(() => {

--- a/frontend/src/components/Deadlines.js
+++ b/frontend/src/components/Deadlines.js
@@ -46,7 +46,7 @@ const Deadlines = ({ course_id }) => {
     }
 
     try {
-      deadlineService.set_deadline({ course_id, date })
+      await deadlineService.set_deadline({ course_id, date })
       setNewDeadline(true)
       window.location.reload()
       //setMessage('Deadline was set successfully!')


### PR DESCRIPTION
Aiemmin tallennettiin pvm suoraan frontista tulevassa muodossa eli 30/3/2023 -muodossa, nyt pitäisi tallentua tietokantaan samassa muodossa kuin created_at eli 2023-03-30. Ei silti varmuutta, että fiksaako se kalenterin ongelman frontissa, koska oma lokaali ei toimi väärin kuten palvelin ? Joten voisiko joku katsoa, kommentoida tms.?

Lisäsin myös fronttiin delete deadlinen ja set deadlinen jälkeen sivun päivityksen ja poistin pop-up-viestit dl lisäyksen onnistumisesta ja poistosta. Mietin, että näyttäisikö se siistimmältä ja korjaisi samalla päivämäärän "päivitysongelmat". Kuitenkin meillä on jo varmistuskysymys poistolle ja dl siirrolle, jonka hyväksymisen jälkeen sivu siis vain ladattaisiin uudelleen. Poikkeustilanteita varten olisi sitten nuo messaget. (Kommentoin nuo messaget, mikäli ei haluta vaihtaa)
Kuulostaa sekavalle, mutta ymmärtänee kattomalla paremmin..